### PR TITLE
Support for .luau

### DIFF
--- a/roblox-studio-icon-theme.json
+++ b/roblox-studio-icon-theme.json
@@ -80,8 +80,11 @@
   },
   "fileExtensions": {
     "lua": "_modulescript",
+    "luau": "_modulescript",
     "server.lua": "_script",
+    "server.luau": "_script",
     "client.lua": "_localscript",
+    "client.luau": "_localscript",
     "rbxl": "_roblox",
     "rbxlx": "_roblox",
     "json": "_json",


### PR DESCRIPTION
The *.luau file extension is accepted and used in Rojo projects, and one that my team use in our projects. I really like these icons, so it'd be nice to see scripts properly too! Thanks :)